### PR TITLE
Fix decimal place logic not working for all numbers

### DIFF
--- a/bot/transactionBuilder.go
+++ b/bot/transactionBuilder.go
@@ -210,14 +210,7 @@ func (tx *SimpleTx) FillTemplate(currency, tag string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	var amountF string
-	if math.Remainder(f*100, 1.0) != 0 {
-		// float has more than 2 remainder digits (e.g. 17.234)
-		amountF = strings.TrimRight(fmt.Sprintf("%f", f), "0")
-	} else {
-		// at max 2 digits after the dot (e.g. 17.10)
-		amountF = fmt.Sprintf("%.2f", f)
-	}
+	amountF := ParseAmount(f)
 	// Add spaces
 	spacesNeeded := c.DOT_INDENT - (utf8.RuneCountInString(string(txRaw[c.STX_ACCF]))) // accFrom
 	spacesNeeded -= CountLeadingDigits(f)                                              // float length before point
@@ -242,6 +235,18 @@ func (tx *SimpleTx) FillTemplate(currency, tag string) (string, error) {
 		currency = amount[1]
 	}
 	return fmt.Sprintf(tpl, txRaw[c.STX_DATE], txRaw[c.STX_DESC], tagS, txRaw[c.STX_ACCF], addSpacesFrom, amountF, currency, txRaw[c.STX_ACCT]), nil
+}
+
+func ParseAmount(f float64) string {
+	var amountF string
+	if math.Abs(math.Remainder(f*100, 1.0)) >= 1e-12 {
+		// float has more than 2 remainder digits (e.g. 17.234)
+		amountF = strings.TrimRight(fmt.Sprintf("%f", f), "0")
+	} else {
+		// at max 2 digits after the dot (e.g. 17.10)
+		amountF = fmt.Sprintf("%.2f", f)
+	}
+	return amountF
 }
 
 func (tx *SimpleTx) Debug() string {

--- a/bot/transactionBuilder_test.go
+++ b/bot/transactionBuilder_test.go
@@ -131,3 +131,14 @@ func TestTaggedTransaction(t *testing.T) {
 		t.Errorf("Tx did not contain tag: %s", template)
 	}
 }
+
+func TestParseAmount(t *testing.T) {
+	helpers.TestExpect(t, bot.ParseAmount(-1), "-1.00", "At least two decimal places should be present")
+	helpers.TestExpect(t, bot.ParseAmount(0), "0.00", "At least two decimal places should be present")
+	helpers.TestExpect(t, bot.ParseAmount(17), "17.00", "At least two decimal places should be present")
+	helpers.TestExpect(t, bot.ParseAmount(16.8), "16.80", "At least two decimal places should be present")
+	helpers.TestExpect(t, bot.ParseAmount(9.8), "9.80", "At least two decimal places should be present")
+
+	helpers.TestExpect(t, bot.ParseAmount(9.801), "9.801", "If higher precision is given, that should be applied")
+	helpers.TestExpect(t, bot.ParseAmount(17.3456), "17.3456", "If higher precision is given, that should be applied")
+}


### PR DESCRIPTION
It can happen that due to float handling the remainder is some very small fraction left from 0.

Closes #65