### PR TITLE
Remove conn leak by closing connections

### DIFF
--- a/bot/controller.go
+++ b/bot/controller.go
@@ -335,6 +335,7 @@ func (bc *BotController) cronNotifications() {
 	if err != nil {
 		bc.Logf(ERROR, nil, "Error getting users to notify: %s", err.Error())
 	}
+	defer rows.Close()
 
 	var (
 		tgChatId  string

--- a/db/crud/monitoring.go
+++ b/db/crud/monitoring.go
@@ -13,6 +13,7 @@ func (r *Repo) HealthGetLogs(lastHours int) (errors int, warnings int, err error
 	if err != nil {
 		return
 	}
+	defer rows.Close()
 	var (
 		level int
 		count int
@@ -37,6 +38,7 @@ func (r *Repo) HealthGetTransactions() (open int, archived int, err error) {
 	if err != nil {
 		return
 	}
+	defer rows.Close()
 	var (
 		isArchived bool
 		count      int
@@ -59,6 +61,7 @@ func (r *Repo) HealthGetUserCount() (count int, err error) {
 	if err != nil {
 		return
 	}
+	defer rows.Close()
 	if rows.Next() {
 		rows.Scan(&count)
 	}
@@ -73,6 +76,7 @@ func (r *Repo) HealthGetCacheStats() (accTo int, accFrom int, txDesc int, err er
 	if err != nil {
 		return
 	}
+	defer rows.Close()
 	var (
 		t     string
 		count int


### PR DESCRIPTION
Health endpoint opened many connections and left the rows open.

Closes #79